### PR TITLE
Modification de la fonction smtp()

### DIFF
--- a/pyutttils/utt_auth.py
+++ b/pyutttils/utt_auth.py
@@ -4,7 +4,7 @@ import requests
 import re
 
 
-def smtp(identifiant="", mdp=""):
+def smtp(identifiant: str = "", mdp: str = "") -> stmplib.SMTP_SSL:
     """Permet d'initier une session SMTP sécurisée sur le serveur mail de l'UTT, soit de manière manuelle, soit de manière
         automatique en fournissant id et mdp
 
@@ -27,9 +27,8 @@ def smtp(identifiant="", mdp=""):
     server_connecte = smtplib.SMTP_SSL('mail.utt.fr')
     server_connecte.connect('mail.utt.fr')
     server_connecte.ehlo()
-    connecte = False
-    manuel = bool(mdp == "" or identifiant == "")
-    while not connecte:
+    manuel = mdp == "" or identifiant == ""
+    while True:
         # On informe l'utilisateur du service sur lequel il se connecte
         if manuel:
             print("Vous allez vous connecter au service de mail de l'UTT\n")
@@ -40,21 +39,12 @@ def smtp(identifiant="", mdp=""):
             return server_connecte
         except smtplib.SMTPAuthenticationError as mail_exception:
             print("Combinaison identifiant / mdp invalide")
-            connecte = False
-            if manuel:
-                identifiant = ""
-                mdp = ""
-            else:
-                del identifiant
-                del mdp
+            if not manuel:
                 raise mail_exception
         except Exception as mail_exception:
-            connecte = False
             print(mail_exception)
             if not manuel:
                 raise mail_exception
-    del identifiant
-    del mdp
 
 
 def cas(service, identifiant="", mdp="", session_web=requests.Session()):


### PR DESCRIPTION
- ajout d'indications de types sur les arguments et le retour de la fonction (attention, compatibilité avec Python 3.8 et + seulement)
- cast explicite du bool lors de la déclaration de la variable `manuel` retiré, car inutile
- Suppression des variables avec `del` retiré, car inutile, puisque Python supprimera de toute manière ces variables en sortie de fonction
- Dans le premier `except`, suppression du premier `if`. Il n'y a pas besoin de remettre la valeur de `identifiant` et `mdp` à `""`, puisque de toute manière, leur valeur sera modifiée dès le début de l'itération suivante de la boucle.
- Suppression de la variable `connecte` ; changement de `while not connecte` en `while True`. La valeur de la variable n'était jamais passé à `True`, ce qui équivaut à un `while True`, donc variable inutile.