### PR TITLE
refactor du constructeur de la classe Semester

### DIFF
--- a/pyutttils/Semester.py
+++ b/pyutttils/Semester.py
@@ -1,20 +1,14 @@
 class Semester:
     def __init__(self, identifier):
+        if identifier[0] not in ('A', 'P'):
+            raise ValueError
         self.short_season = identifier[0]
-        if self.short_season == "A":
-            self.full_season = "Automne"
-        if self.short_season == "P":
-            self.full_season = "Printemps"
-
-        if len(identifier) == 3:  # "P22"
-            self.short_year = int(identifier[1:3])
-            self.full_year = 2000 + self.short_year
-        elif len(identifier) == 5:  # "P2022"
-            self.full_year = int(identifier[1:])
-            self.short_year = int(identifier[3:])
-        else:  # "Printemps 2022"
-            self.full_year = int(identifier.split(" ")[1])
-            self.short_year = int(identifier.split(" ")[1][2:])
+        self.full_season = ["Automne", "Printemps"][identifier[0] == "P"]
+        
+        # work with "P22" and "P2022" and "Printemps 2022"
+        self.short_year = int(identifier.strip()[-2:])
+        self.full_year = 2000 + self.short_year
+        
         self.long_code = self.short_season + str(self.full_year)
         self.full_name = self.full_season + " " + str(self.full_year)
 


### PR DESCRIPTION
On peut remarquer que dans tous les cas de figures, le paramètre du constructeur se termine toujours par les deux chiffres de l'année courte. On peut se servir de ça pour remplacer toutes les conditions par une unique déclaration de `self.short_year` puis construire `self.full_year`.